### PR TITLE
Add getEvent function to parse event data

### DIFF
--- a/linebotAPI.gs
+++ b/linebotAPI.gs
@@ -1,3 +1,5 @@
-const myFunction = () => {
+const getEvent = (e) => {
+  const event = JSON.parse(e.postData.contents).events[0];
   
+  return event;
 }


### PR DESCRIPTION
This pull request adds a new function called `getEvent` that parses event data from the `postData` contents. This function is useful for extracting event information from the `events` array in the `postData` contents.